### PR TITLE
Change coordtype

### DIFF
--- a/pynadjust/surveyconvert/ski-ascii.py
+++ b/pynadjust/surveyconvert/ski-ascii.py
@@ -40,7 +40,7 @@ def stn2xml(skiasciifile):
     namelist = []
     # Station constants
     constraint = 'FFF'
-    coordtype = 'LLH'
+    coordtype = 'LLh'
     for line in stnlines:
         linetype = line[0][0:2]
         if line[0] == "@%Coordinate":


### PR DESCRIPTION
Coordtype changed to 'LLh' to accommodate ellipsoidal height outputs from Leica Infinity. This will allow proper height input during DynAdjust import. Bug identified by Bill Payze.